### PR TITLE
feat: Add pupil phase tilts to model beam steering

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,22 @@ HalfmoonPhase.MINUS_45
 HalfmoonPhase.PLUS_45
 ```
 
+#### Beam Steering with a Phase Ramp
+
+A linear phase ramp (blazed grating) can be composed onto any `InputField`, regardless of how it was constructed, to model beam-steering elements such as galvo mirrors or SLM tilt patterns:
+
+```python
+steered = halfmoon.with_phase_ramp(tilt_pupil=(0.5, 0.0))
+```
+
+`tilt_pupil` specifies the phase tilt in radians at the pupil edge (`px=1`/`py=1`) along the x- and y-directions, and may point in any direction, e.g. `(1.0, 0.0)` steers along x, `(0.0, 1.0)` along y, `(1.0, 1.0)` diagonally.
+
+See `scripts/displaced_gaussian.py` for a runnable example that steers a focused Gaussian beam with `tilt_pupil=(-2.0, 1.0)` and plots the resulting displacement (requires the `plot` extra):
+
+```console
+uv run displaced_gaussian
+```
+
 ### Pupil
 
 A `Pupil` instance is defined as follows:
@@ -236,6 +252,12 @@ The pupil mesh samples are always taken at the centers of their corresponding ce
 
 Unlike the pupil mesh, the origin of the coordinate system is sampled by the focal field mesh because of how the FFT works. It lies at pixel `L / 2`, where `L` is the linear square mesh size. The focal field mesh spacing is `dx = λ/(2·NA·2^padding_factor)` and total the FOV is `L * dx = mesh_size * λ/(2·NA)`, i.e. the FOV is independent of any padding applied before the FFT.
 
+### Example Scripts
+
+Command line scripts that illustrate the use of Just Focus may found in <src/leb/just_focus/scripts>. They are also available on the command line, i.e. `uv run gaussian`.
+
+Scripts require the `plot` set of optional dependencies. See [the installation instructions](#extras) for more details about how to install them.
+
 ## Development
 
 ### Set up the development environment
@@ -264,6 +286,25 @@ pytest
 - InFocus (MATLAB) <https://github.com/QF06/InFocus>
 - Debye Diffraction Code (MATLAB and Python) <https://github.com/jdmanton/debye_diffraction_code>
 - PyFocus <https://github.com/fcaprile/PyFocus>
+- PSF Generator (Java) <https://bigwww.epfl.ch/algorithms/psfgenerator/>
+
+### Is Just Focus for me?
+
+- If you want a fast PSF calculator that runs on the GPU, then use [psf-generator](https://github.com/Biomedical-Imaging-Group/psf_generator).
+- If you want a GUI and/or a Windows-installable executable, then use [PyFocus](https://github.com/fcaprile/PyFocus).
+- If you want a MATLAB tool, then use [InFocus](https://github.com/QF06/InFocus).
+- If you want a Java/ImageJ/Fiji/Icy tool, use [PSF Generator](https://bigwww.epfl.ch/algorithms/psfgenerator/).
+
+If you want 
+
+1. a Python package
+2. that computes vectorial focal fields
+2. with a simple API and
+3. a small number of dependencies,
+3. you do not care about computation speed or optimizations, and
+4. you want the physics clearly reflected in the code,
+
+then Just Focus might be for you.
 
 ## Resources
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ plot = [
 [project.scripts]
 gaussian = "leb.just_focus.scripts.gaussian:main"
 halfmoon = "leb.just_focus.scripts.halfmoon:main"
+displaced_gaussian = "leb.just_focus.scripts.displaced_gaussian:main"
 
 [dependency-groups]
 dev = [

--- a/src/leb/just_focus/__init__.py
+++ b/src/leb/just_focus/__init__.py
@@ -1,4 +1,4 @@
 from .dtypes import Float, Complex
-from .inputs import InputField, HalfmoonPhase, Polarization
+from .inputs import InputField, HalfmoonPhase, Polarization, gaussian_amplitude, phase_ramp
 from .focal_fields import FocalField
 from .pupil import Pupil, Stop

--- a/src/leb/just_focus/inputs.py
+++ b/src/leb/just_focus/inputs.py
@@ -1,7 +1,7 @@
 """Input fields for the propagation algorithm."""
 
 from __future__ import annotations
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import StrEnum
 
 import numpy as np
@@ -70,6 +70,67 @@ class HalfmoonPhase(StrEnum):
         return phase_x, phase_y
 
 
+def gaussian_amplitude(
+    beam_center_pupil: tuple[float, float],
+    waist_pupil: float | tuple[float, float],
+    mesh_size: int
+) -> tuple[NDArray[Float], NDArray[Float]]:
+    """Compute a Gaussian amplitude for the pupil field.
+
+    Parameters
+    ----------
+    beam_center_pupil : tuple of float
+        The center of the Gaussian beam in normalized pupil coordinates (x, y).
+    waist_pupil : float or tuple of float
+        The waist size of the Gaussian beam in normalized pupil coordinates. If a
+        single float is provided, it is used for both x and y dimensions.
+    mesh_size : int
+        The size of the mesh grid for the pupil field.
+
+    Returns
+    -------
+    tuple of NDArray[Float]
+        The Gaussian amplitude for the x- and y-directions, respectively.
+
+    """
+    if isinstance(waist_pupil, (int, float)):
+        waist_x = waist_y = waist_pupil
+    else:
+        waist_x, waist_y = waist_pupil
+
+    normed_coords = np.linspace(-1, 1, mesh_size)
+    x, y = np.meshgrid(normed_coords, normed_coords)
+    x0: float = beam_center_pupil[0]
+    y0: float = beam_center_pupil[1]
+    amplitude_x = np.exp(-(x - x0)**2 / waist_x**2 - (y - y0)**2 / waist_y**2)
+    amplitude_y = np.copy(amplitude_x)
+
+    return amplitude_x, amplitude_y
+
+
+def phase_ramp(tilt_pupil: tuple[float, float], mesh_size: int) -> NDArray[Float]:
+    """Compute a linear phase ramp (blazed grating) across the pupil.
+
+    Parameters
+    ----------
+    tilt_pupil : tuple of float
+        Phase tilt in radians at the pupil edge (px=1, py=1) along the pupil's
+        x- and y-directions, i.e. (tilt_x, tilt_y).
+    mesh_size : int
+        The size of the mesh grid for the pupil field.
+
+    Returns
+    -------
+    NDArray[Float]
+        The phase ramp evaluated on the normalized pupil mesh, i.e.
+        phase(px, py) = tilt_x * px + tilt_y * py.
+
+    """
+    tilt_x, tilt_y = tilt_pupil
+    normed_coords = np.linspace(-1, 1, mesh_size)
+    px, py = np.meshgrid(normed_coords, normed_coords)
+    return (tilt_x * px + tilt_y * py).astype(Float)
+
 
 @dataclass
 class InputField:
@@ -99,8 +160,12 @@ class InputField:
     -------
     gaussian_pupil(beam_center_pupil, waist_pupil, mesh_size, polarization)
         Create a Gaussian pupil field with a specified waist size.
+    gaussian_halfmoon_pupil(beam_center_pupil, waist_pupil, mesh_size, polarization, orientation, phase, phase_mask_center)
+        Create a halfmoon pupil field with a Gaussian beam amplitude.
     uniform_pupil(mesh_size, polarization)
         Create a uniform pupil field with specified polarization.
+    with_phase_ramp(tilt_pupil)
+        Return a new InputField with a linear phase ramp added to the phase.
 
     """
     amplitude_x: NDArray[Float]
@@ -109,27 +174,6 @@ class InputField:
     phase_y: NDArray[Float]
     polarization_x: NDArray[Complex]
     polarization_y: NDArray[Complex]
-
-    @staticmethod
-    def _gaussian_amplitude(
-        beam_center_pupil: tuple[float, float],
-        waist_pupil: float | tuple[float, float],
-        mesh_size: int
-    ) -> tuple[NDArray[Float], NDArray[Float]]:
-        """Calculate a Gaussian amplitude for the pupil field."""
-        if isinstance(waist_pupil, (int, float)):
-            waist_x = waist_y = waist_pupil
-        else:
-            waist_x, waist_y = waist_pupil
-
-        normed_coords = np.linspace(-1, 1, mesh_size)
-        x, y = np.meshgrid(normed_coords, normed_coords)
-        x0: float = beam_center_pupil[0]
-        y0: float = beam_center_pupil[1]
-        amplitude_x = np.exp(-(x - x0)**2 / waist_x**2 - (y - y0)**2 / waist_y**2)
-        amplitude_y = np.copy(amplitude_x)
-
-        return amplitude_x, amplitude_y
 
     @classmethod
     def gaussian_pupil(
@@ -160,7 +204,7 @@ class InputField:
 
         """
         polarization_x, polarization_y = polarization.arrays(mesh_size)
-        amplitude_x, amplitude_y = cls._gaussian_amplitude(beam_center_pupil, waist_pupil, mesh_size)
+        amplitude_x, amplitude_y = gaussian_amplitude(beam_center_pupil, waist_pupil, mesh_size)
 
         phase_x = np.zeros((mesh_size, mesh_size), dtype=Float)
         phase_y = np.zeros((mesh_size, mesh_size), dtype=Float)
@@ -213,7 +257,7 @@ class InputField:
 
         """
         polarization_x, polarization_y = polarization.arrays(mesh_size)
-        amplitude_x, amplitude_y = cls._gaussian_amplitude(beam_center_pupil, waist_pupil, mesh_size)
+        amplitude_x, amplitude_y = gaussian_amplitude(beam_center_pupil, waist_pupil, mesh_size)
 
         phase_x, phase_y = orientation.arrays(mesh_size, phase, phase_mask_center)
 
@@ -229,7 +273,7 @@ class InputField:
     @classmethod
     def uniform_pupil(cls, mesh_size: int, polarization: Polarization) -> InputField:
         polarization_x, polarization_y = polarization.arrays(mesh_size)
-            
+
         amplitude_x = np.ones((mesh_size, mesh_size), dtype=Float)
         amplitude_y = np.ones((mesh_size, mesh_size), dtype=Float)
         phase_x = np.zeros((mesh_size, mesh_size), dtype=Float)
@@ -242,4 +286,38 @@ class InputField:
             phase_y=phase_y,
             polarization_x=polarization_x,
             polarization_y=polarization_y,
+        )
+
+    def with_phase_ramp(self, tilt_pupil: tuple[float, float]) -> InputField:
+        """Return a new InputField with a linear phase ramp added to the phase.
+
+        Models a blazed-grating-style beam-steering element (e.g. a galvo mirror or
+        SLM tilt pattern) as an abstract phase tilt, composable onto any InputField
+        regardless of how it was constructed. Mapping this tilt to a physical beam
+        displacement requires a separate, system-specific calibration.
+
+        Parameters
+        ----------
+        tilt_pupil : tuple of float
+            Phase tilt in radians at the pupil edge (px=1, py=1) along the pupil's
+            x- and y-directions, i.e. (tilt_x, tilt_y). Any combination of tilt_x
+            and tilt_y is allowed, giving a ramp in any direction across the pupil
+            (not limited to 45 degrees) — e.g. (1.0, 0.0) steers along x, (0.0, 1.0)
+            along y, (1.0, 1.0) diagonally. The resulting ramp array is added to
+            both of InputField's phase_x and phase_y attributes (its two
+            polarization-channel phase arrays), since a physical steering element
+            deflects the whole beam rather than one Jones component selectively.
+
+        Returns
+        -------
+        InputField
+            A new instance with the ramp added to phase_x and phase_y. The
+            original InputField is not modified.
+
+        """
+        ramp = phase_ramp(tilt_pupil, self.phase_x.shape[0])
+        return replace(
+            self,
+            phase_x=self.phase_x + ramp,
+            phase_y=self.phase_y + ramp,
         )

--- a/src/leb/just_focus/scripts/displaced_gaussian.py
+++ b/src/leb/just_focus/scripts/displaced_gaussian.py
@@ -1,0 +1,101 @@
+"""Generate the focal fields from a Gaussian beam steered by a phase ramp and visualize the results."""
+
+import matplotlib.pyplot as plt
+from matplotlib.patches import Circle
+import numpy as np
+
+from leb.just_focus import InputField, Polarization, Pupil, Stop
+
+
+def main(plot=True) -> None:
+    mesh_size = 64
+    tilt_pupil = (-2.0, 1.0)
+
+    pupil = Pupil(
+        na=1.4,
+        refractive_index=1.518,
+        wavelength_um=0.561,
+        mesh_size=mesh_size,
+        stop=Stop.TANH,
+    )
+
+    inputs = InputField.gaussian_pupil(
+        beam_center_pupil=(0.0, 0.0),
+        waist_pupil=1.0,
+        mesh_size=mesh_size,
+        polarization=Polarization.LINEAR_Y,
+    ).with_phase_ramp(tilt_pupil)
+
+    results = pupil.propgate(0.0, inputs, padding_factor=4)
+
+    _, axs = plt.subplots(3, 2, figsize=(8, 10))
+    plt.suptitle(f"tilt_pupil = {tilt_pupil}")
+
+    # amplitude_x/y and phase_x/y are identical here (LINEAR_Y polarization,
+    # ramp applied equally to both), so show one of each.
+    axs[0, 0].imshow(
+        inputs.amplitude_x,
+        vmin=0,
+        vmax=1,
+        origin="lower",
+        extent=(pupil.x_mm[0], pupil.x_mm[-1], pupil.y_mm[0], pupil.y_mm[-1]),
+    )
+    axs[0, 0].add_artist(Circle((0, 0), radius=pupil.stop_radius_mm, color='k', fill=False, linewidth=2))
+    axs[0, 0].set_ylabel("y, mm")
+    axs[0, 0].set_title("Amplitude")
+
+    axs[0, 1].imshow(
+        inputs.phase_x,
+        origin="lower",
+        extent=(pupil.x_mm[0], pupil.x_mm[-1], pupil.y_mm[0], pupil.y_mm[-1]),
+    )
+    axs[0, 1].add_artist(Circle((0, 0), radius=pupil.stop_radius_mm, color='k', fill=False, linewidth=2))
+    axs[0, 1].set_title("Phase")
+
+    axs[1, 0].imshow(
+        np.abs(inputs.polarization_x),
+        vmin=0,
+        vmax=1,
+        origin="lower",
+        extent=(pupil.x_mm[0], pupil.x_mm[-1], pupil.y_mm[0], pupil.y_mm[-1]),
+    )
+    axs[1, 0].add_artist(Circle((0, 0), radius=pupil.stop_radius_mm, color='k', fill=False, linewidth=2))
+    axs[1, 0].set_ylabel("y, mm")
+    axs[1, 0].set_title("Polarization, x")
+
+    axs[1, 1].imshow(
+        np.abs(inputs.polarization_y),
+        vmin=0,
+        vmax=1,
+        origin="lower",
+        extent=(pupil.x_mm[0], pupil.x_mm[-1], pupil.y_mm[0], pupil.y_mm[-1]),
+    )
+    axs[1, 1].add_artist(Circle((0, 0), radius=pupil.stop_radius_mm, color='k', fill=False, linewidth=2))
+    axs[1, 1].set_title("Polarization, y")
+
+    axs[2, 0].imshow(pupil.stop_arr, vmin=0, vmax=1)
+    axs[2, 0].set_title("Stop")
+    axs[2, 0].set_xlabel("x, mm")
+    axs[2, 0].set_ylabel("y, mm")
+
+    axs[2, 1].imshow(
+        results.intensity(normalize=True),
+        vmin=0,
+        vmax=1,
+        origin="lower",
+        extent=(results.x_um[0], results.x_um[-1], results.y_um[0], results.y_um[-1]),
+    )
+    axs[2, 1].set_title("Intensity")
+    axs[2, 1].set_xlabel(r"x, $\mu m$")
+    axs[2, 1].set_xlim(-1, 1)
+    axs[2, 1].set_ylim(-1, 1)
+
+    plt.tight_layout()
+
+    if plot:
+        plt.show()
+
+
+if __name__ == "__main__":
+    np.seterr("raise")
+    main()

--- a/tests/scripts/test_displaced_gaussian.py
+++ b/tests/scripts/test_displaced_gaussian.py
@@ -1,0 +1,5 @@
+from leb.just_focus.scripts.displaced_gaussian import main
+
+
+def test_displaced_gaussian_script() -> None:
+    main(plot=False)

--- a/tests/unit/test_inputs.py
+++ b/tests/unit/test_inputs.py
@@ -1,0 +1,78 @@
+import numpy as np
+import pytest
+
+from leb.just_focus import Float, HalfmoonPhase, InputField, Polarization, gaussian_amplitude, phase_ramp
+
+
+def test_gaussian_amplitude_shape_and_dtype():
+    mesh_size = 8
+    amplitude_x, amplitude_y = gaussian_amplitude((0.0, 0.0), 1.0, mesh_size)
+
+    assert amplitude_x.shape == (mesh_size, mesh_size)
+    assert amplitude_y.shape == (mesh_size, mesh_size)
+
+
+def test_phase_ramp_shape_and_dtype():
+    mesh_size = 8
+    ramp = phase_ramp((0.5, -0.25), mesh_size)
+
+    assert ramp.shape == (mesh_size, mesh_size)
+    assert ramp.dtype == Float
+
+
+def test_phase_ramp_zero_at_center():
+    mesh_size = 65  # odd so that the linspace includes an exact 0.0 sample
+    ramp = phase_ramp((1.0, 1.0), mesh_size)
+
+    center = mesh_size // 2
+    assert ramp[center, center] == pytest.approx(0.0)
+
+
+def test_phase_ramp_value_at_pupil_edges():
+    mesh_size = 65
+    tilt_x, tilt_y = 0.7, -1.3
+    ramp = phase_ramp((tilt_x, tilt_y), mesh_size)
+
+    center = mesh_size // 2
+    # np.meshgrid default "xy" indexing: px varies along columns, py along rows.
+    assert ramp[center, -1] == pytest.approx(tilt_x)   # px = +1, py = 0
+    assert ramp[center, 0] == pytest.approx(-tilt_x)   # px = -1, py = 0
+    assert ramp[-1, center] == pytest.approx(tilt_y)   # py = +1, px = 0
+    assert ramp[0, center] == pytest.approx(-tilt_y)   # py = -1, px = 0
+
+
+def test_with_phase_ramp_adds_to_existing_phase_without_mutating_original():
+    mesh_size = 65
+    original = InputField.gaussian_halfmoon_pupil(
+        beam_center_pupil=(0.0, 0.0),
+        waist_pupil=1.0,
+        mesh_size=mesh_size,
+        polarization=Polarization.LINEAR_Y,
+        orientation=HalfmoonPhase.HORIZONTAL,
+        phase=np.pi,
+    )
+    original_phase_x = original.phase_x.copy()
+    original_phase_y = original.phase_y.copy()
+
+    tilt_pupil = (0.5, -0.25)
+    tilted = original.with_phase_ramp(tilt_pupil)
+    ramp = phase_ramp(tilt_pupil, mesh_size)
+
+    assert np.allclose(tilted.phase_x, original_phase_x + ramp)
+    assert np.allclose(tilted.phase_y, original_phase_y + ramp)
+    # The original InputField must be untouched.
+    assert np.array_equal(original.phase_x, original_phase_x)
+    assert np.array_equal(original.phase_y, original_phase_y)
+    # Amplitude and polarization pass through unchanged.
+    assert np.array_equal(tilted.amplitude_x, original.amplitude_x)
+    assert np.array_equal(tilted.amplitude_y, original.amplitude_y)
+    assert np.array_equal(tilted.polarization_x, original.polarization_x)
+    assert np.array_equal(tilted.polarization_y, original.polarization_y)
+
+
+def test_with_phase_ramp_dtype_preserved():
+    mesh_size = 32
+    field = InputField.uniform_pupil(mesh_size, Polarization.LINEAR_X).with_phase_ramp((1.0, 1.0))
+
+    assert field.phase_x.dtype == Float
+    assert field.phase_y.dtype == Float


### PR DESCRIPTION
A method `with_phase_ramp` is added to the `InputField` class to compose linear phase ramps on top of a pupil phase. This allows the library to model beam steering set ups.